### PR TITLE
fix install package python-virtualenv to all distribution

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install virtualenv package
   apt:
-    name: python-virtualenv
+    name: python{% if ansible_lsb.major_release > '10' %}3{% endif %}-virtualenv
     state: present
     update_cache: yes
     cache_valid_time: "{{ apt_cache_time }}"


### PR DESCRIPTION
Installing the python3-virtualenv package inside python-virtualenv for debian 11 and above